### PR TITLE
fix package.json main path

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "clipmaster-9000",
   "version": "1.0.0",
   "description": "A guide to building your first menubar application with Electron. ",
-  "main": "lib/main.js",
+  "main": "app/main.js",
   "scripts": {
     "start": "electron .",
     "build": "electron-packager . 'Clipmaster 3000' --platform=all --arch=all --version=0.36.8"


### PR DESCRIPTION
Change the file path of the main path in package.json, so when running the tutorial the file path is the same and the application will run.